### PR TITLE
In which our hero changes sed quoting for tags

### DIFF
--- a/rdphoney.run.j2
+++ b/rdphoney.run.j2
@@ -48,7 +48,7 @@ setup_rdphoney_conf () {
     sed -i "s/port = 10000/port = ${server_port}/g" rdphoney.cfg
     sed -i "s/identifier = abc123/identifier = ${uid}/g" rdphoney.cfg
     sed -i "s/secret = secret/secret = ${secret}/g" rdphoney.cfg
-    sed -i "s/tags =.*/tags = ${tags}/g" rdphoney.cfg
+    sed -i "s|tags =.*|tags = ${tags}|g" rdphoney.cfg
     sed -i "s/debug=false/debug=${debug}/" rdphoney.cfg
 
     popd


### PR DESCRIPTION
This change will allow for all characters OTHER THAN pipes ('|') to be used in the sysconfig TAGS variable.